### PR TITLE
fix: 纯数字短链访问失败-路由缺失

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -49,6 +49,10 @@ const router = createRouter({
       redirect: redirectImport,
     },
     {
+      path: '/:github_asset_id(\\d+)',
+      redirect: redirectImport,
+    },
+    {
       path: '/import',
       redirect(to) {
         return {


### PR DESCRIPTION
#11

已修好，根因就是路由缺失。

**原因**
- 你访问 `https://li.chenge.eu.org/18637952` 时，当前路由没有 `/<数字>` 规则。
- 所以直接命中 `/:pathMatch(.*)*` -> 404。
- 官方链路能工作是因为有“数字 ID -> 导入页”的重定向流程。

**修复**
- 在 `src/router.ts` 增加了数字短链路由，并复用已有 `redirectImport`：
  - `path: '/:github_asset_id(\\d+)'`
  - `redirect: redirectImport`

这样现在链路会变成：
1. `/<id>`
2. `/i?url=https://github.com/user-attachments/files/<id>/file.zip`
3. 导入完成后跳 `/snapshot/<snapshotId>`

这和你观察到的官方流程一致，且性能开销几乎为 0（纯路由重定向，不增加额外请求逻辑）。
已通过 `pnpm -s tsc --noEmit`。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for numeric asset IDs accessible directly at the root path, enabling streamlined access to import functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->