### PR TITLE
Codex/snapshot card seams

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,6 +1,6 @@
 # Refactor Todo
 
-Last updated: 2026-03-22
+Last updated: 2026-05-21
 
 ## Current focus
 
@@ -22,6 +22,10 @@ Keep `offical` mergeable while reducing Plus-only runtime risk.
 
 ## Done in this round
 
+- [x] Extract shared `WindowCard` seam
+  - [x] Add neutral `src/composables/useSnapshotWindowCard.ts`
+  - [x] Reuse shared tree state, focus scrolling, node props, and snapshot metadata in base and Plus `WindowCard`
+  - [x] Keep Plus-only quick-find label rendering inside `src/views/plus/snapshot/WindowCard.vue`
 - [x] Add first Adapter contract tests
   - [x] Add Vitest / Vue Test Utils test infrastructure
   - [x] Cover `HomePage` and `DevicePage` route-level slot wiring

--- a/src/composables/useSnapshotWindowCard.ts
+++ b/src/composables/useSnapshotWindowCard.ts
@@ -35,9 +35,12 @@ export function useSnapshotWindowCard(options: {
   const expandedKeys = shallowRef<number[]>([]);
   const selectedKeys = shallowRef<number[]>([]);
   const treeRef = shallowRef<TreeInst>();
-  const toRawNode = (option: TreeOption): RawNode => option as RawNode;
+  const toRawNode = (option: TreeOption): RawNode =>
+    option as unknown as RawNode;
   const rootTreeData = computed<TreeOption[]>(() =>
-    options.rootNode.value ? [options.rootNode.value as TreeOption] : [],
+    options.rootNode.value
+      ? [options.rootNode.value as unknown as TreeOption]
+      : [],
   );
 
   watch(

--- a/src/composables/useSnapshotWindowCard.ts
+++ b/src/composables/useSnapshotWindowCard.ts
@@ -1,0 +1,161 @@
+import {
+  computed,
+  nextTick,
+  shallowRef,
+  watch,
+  type HTMLAttributes,
+  type Ref,
+  type ShallowRef,
+  type VNode,
+} from 'vue';
+import type { TreeInst, TreeOption, TreeProps } from 'naive-ui';
+import {
+  getAppInfo,
+  getDevice,
+  getGkdAppInfo,
+  getNodeLabel,
+  getNodeStyle,
+} from '@/utils/node';
+import { delay } from '@/utils/others';
+
+type RenderLabelOverride = (props: {
+  option: RawNode;
+  label: string | VNode;
+}) => VNode | string;
+
+export function useSnapshotWindowCard(options: {
+  snapshot: ShallowRef<Snapshot | undefined>;
+  rootNode: ShallowRef<RawNode | undefined>;
+  focusNode: ShallowRef<RawNode | undefined>;
+  focusTime: Ref<number>;
+  updateFocusNode: (node: RawNode) => void;
+  treeContainer?: Readonly<ShallowRef<HTMLElement | null>>;
+}) {
+  let lastClickId = Number.NaN;
+  const expandedKeys = shallowRef<number[]>([]);
+  const selectedKeys = shallowRef<number[]>([]);
+  const treeRef = shallowRef<TreeInst>();
+  const toRawNode = (option: TreeOption): RawNode => option as RawNode;
+  const rootTreeData = computed<TreeOption[]>(() =>
+    options.rootNode.value ? [options.rootNode.value as TreeOption] : [],
+  );
+
+  watch(
+    [() => options.focusNode.value, () => options.focusTime.value],
+    async () => {
+      if (!options.focusNode.value) return;
+      const key = options.focusNode.value.id;
+      nextTick().then(async () => {
+        await delay(300);
+        if (key !== options.focusNode.value?.id) return;
+        if (lastClickId === key) {
+          lastClickId = Number.NaN;
+          return;
+        }
+        selectedKeys.value = [key];
+        const nodeRef = options.treeContainer?.value?.querySelector(
+          `[data-node-id="${key}"]`,
+        );
+        if (nodeRef) {
+          nodeRef.scrollIntoView({
+            behavior: 'smooth',
+            block: 'center',
+          });
+          return;
+        }
+        await delay(options.treeContainer ? 300 : 0);
+        treeRef.value?.scrollTo({ key, behavior: 'smooth', debounce: true });
+      });
+
+      let parent = options.focusNode.value.parent;
+      if (!parent) return;
+      const nextExpandedKeys = new Set(expandedKeys.value);
+      while (parent) {
+        nextExpandedKeys.add(parent.id);
+        parent = parent.parent;
+      }
+      if (
+        nextExpandedKeys.size == expandedKeys.value.length &&
+        expandedKeys.value.every((v) => nextExpandedKeys.has(v))
+      )
+        return;
+      expandedKeys.value = [...nextExpandedKeys];
+    },
+  );
+
+  const treeFilter: NonNullable<TreeProps['filter']> = (_pattern, node) =>
+    toRawNode(node).id === options.focusNode.value?.id;
+
+  const treeNodeProps: NonNullable<TreeProps['nodeProps']> = ({
+    option,
+  }): HTMLAttributes & Record<string, unknown> => {
+    const rawNode = toRawNode(option);
+    const style = getNodeStyle(rawNode, options.focusNode.value);
+    return {
+      onClick: () => {
+        lastClickId = rawNode.id;
+        options.updateFocusNode(rawNode);
+      },
+      style: { '--n-node-text-color': style.color, ...style },
+      class: 'whitespace-nowrap',
+      'data-node-id': String(rawNode.id),
+    };
+  };
+
+  const createRenderLabel =
+    (override?: RenderLabelOverride): NonNullable<TreeProps['renderLabel']> =>
+    ({ option }) => {
+      const rawNode = toRawNode(option);
+      const label = getNodeLabel(rawNode);
+      return override?.({ option: rawNode, label }) ?? label;
+    };
+
+  const app = computed(() =>
+    options.snapshot.value ? getAppInfo(options.snapshot.value) : null,
+  );
+
+  const deviceName = computed(() => {
+    if (!options.snapshot.value) return '';
+    const device = getDevice(options.snapshot.value);
+    return `${device.manufacturer} Android ${device.release || ''}`;
+  });
+
+  const activityId = computed(() => {
+    const snapshot = options.snapshot.value;
+    if (!snapshot) return '';
+    const { activityId: value, appId } = snapshot;
+    if (!value || !appId) return '';
+    return value.startsWith(appId) && value[appId.length] === '.'
+      ? value.substring(appId.length)
+      : value;
+  });
+
+  const gkdVersionName = computed(() => {
+    if (!options.snapshot.value) return undefined;
+    const versionName = getGkdAppInfo(options.snapshot.value).versionName;
+    return versionName ? `GKD@${versionName}` : undefined;
+  });
+
+  const appVersionCodeText = computed(() => {
+    const versionCode = app.value?.versionCode;
+    return versionCode == null ? '' : String(versionCode);
+  });
+
+  const isSystem = computed(() => app.value?.isSystem ?? false);
+
+  return {
+    expandedKeys,
+    selectedKeys,
+    treeRef,
+    rootTreeData,
+    treeFilter,
+    treeNodeProps,
+    createRenderLabel,
+    app,
+    deviceName,
+    activityId,
+    gkdVersionName,
+    appVersionCodeText,
+    isSystem,
+  };
+}

--- a/src/views/plus/snapshot/WindowCard.vue
+++ b/src/views/plus/snapshot/WindowCard.vue
@@ -1,17 +1,10 @@
 <script setup lang="tsx">
 import ActionCard from '@/components/ActionCard.vue';
 import GapList from '@/components/GapList';
+import { useSnapshotWindowCard } from '@/composables/useSnapshotWindowCard';
 import { message } from '@/utils/discrete';
-import {
-  getAppInfo,
-  getDevice,
-  getGkdAppInfo,
-  getNodeLabel,
-  getNodeStyle,
-} from '@/utils/node';
 import { copy, delay } from '@/utils/others';
-import type { TreeInst, TreeOption, TreeProps } from 'naive-ui';
-import type { HTMLAttributes, ShallowRef } from 'vue';
+import type { ShallowRef } from 'vue';
 import { h } from 'vue';
 import SvgIcon from '@/components/SvgIcon.vue';
 import { useWindowQuickFind } from '@/composables/plus/useWindowQuickFind';
@@ -25,73 +18,29 @@ const snapshot = snapshotStore.snapshot as ShallowRef<Snapshot>;
 const rootNode = snapshotStore.rootNode as ShallowRef<RawNode>;
 const { getNodeQuickFindMeta } = useWindowQuickFind(rootNode);
 
-let lastClickId = Number.NaN;
-const expandedKeys = shallowRef<number[]>([]);
-const selectedKeys = shallowRef<number[]>([]);
-const treeRef = shallowRef<TreeInst>();
-const toRawNode = (option: TreeOption): RawNode => option as RawNode;
-const rootTreeData = computed<TreeOption[]>(() =>
-  rootNode.value ? [rootNode.value as TreeOption] : [],
-);
-
-watch([() => focusNode.value, () => focusTime.value], async () => {
-  if (!focusNode.value) return;
-  const key = focusNode.value.id;
-  nextTick().then(async () => {
-    await delay(300);
-    if (key === focusNode.value?.id) {
-      if (lastClickId === key) {
-        // 当点击节点树中的节点时, 不滚动
-        lastClickId = Number.NaN;
-        return;
-      }
-      selectedKeys.value = [key];
-      treeRef.value?.scrollTo({ key, behavior: 'smooth', debounce: true });
-    }
-  });
-  let parent = focusNode.value.parent;
-  if (!parent) {
-    return;
-  }
-  const s = new Set(expandedKeys.value);
-  while (parent) {
-    s.add(parent.id);
-    parent = parent.parent;
-  }
-  if (
-    s.size == expandedKeys.value.length &&
-    expandedKeys.value.every((v) => s.has(v))
-  ) {
-    return;
-  }
-  expandedKeys.value = [...s];
+const {
+  expandedKeys,
+  selectedKeys,
+  treeRef,
+  rootTreeData,
+  treeFilter,
+  treeNodeProps,
+  createRenderLabel,
+  app,
+  deviceName,
+  activityId,
+  gkdVersionName,
+  appVersionCodeText,
+  isSystem,
+} = useSnapshotWindowCard({
+  snapshot,
+  rootNode,
+  focusNode,
+  focusTime,
+  updateFocusNode,
 });
 
-const treeFilter: NonNullable<TreeProps['filter']> = (_pattern, node) => {
-  return toRawNode(node).id === focusNode.value?.id;
-};
-const treeNodeProps: NonNullable<TreeProps['nodeProps']> = ({
-  option,
-}): HTMLAttributes & Record<string, unknown> => {
-  const rawNode = toRawNode(option);
-  const style = getNodeStyle(rawNode, focusNode.value);
-  return {
-    onClick: () => {
-      lastClickId = rawNode.id;
-      updateFocusNode(rawNode);
-    },
-    style: {
-      '--n-node-text-color': style.color,
-      ...style,
-    },
-    class: 'whitespace-nowrap',
-    'data-node-id': String(rawNode.id),
-  };
-};
-
-const renderLabel: NonNullable<TreeProps['renderLabel']> = ({ option }) => {
-  const rawNode = toRawNode(option);
-  const label = getNodeLabel(rawNode);
+const renderLabel = createRenderLabel(({ option: rawNode, label }) => {
   const meta = getNodeQuickFindMeta(rawNode);
   if (!meta?.has) {
     return label;
@@ -128,34 +77,6 @@ const renderLabel: NonNullable<TreeProps['renderLabel']> = ({ option }) => {
       }),
     ],
   );
-};
-
-const deviceName = computed(() => {
-  // 1. 如果没有快照，返回空字符串或占位符
-  if (!snapshot.value) return '';
-  const device = getDevice(snapshot.value);
-  return `${device.manufacturer} Android ${device.release || ''}`;
-});
-
-const isSystem = computed(() => {
-  // 2. 增加可选链 ?. 防御，防止 snapshot 为空时调用 getAppInfo 崩溃
-  if (!snapshot.value) return false;
-  return getAppInfo(snapshot.value)?.isSystem ?? false;
-});
-
-const activityId = computed(() => {
-  // 3. 这里的 snapshot.value.activityId 在初始状态下会直接报错
-  const snap = snapshot.value;
-  if (!snap) return '';
-
-  const v = snap.activityId;
-  const appId = snap.appId;
-  if (!v || !appId) return '';
-
-  if (v.startsWith(appId) && v[appId.length] === '.') {
-    return v.substring(appId.length);
-  }
-  return v;
 });
 
 const onDelete = async () => {
@@ -165,16 +86,6 @@ const onDelete = async () => {
     path: `/`,
   });
 };
-const gkdVersionName = computed(() => {
-  if (!snapshot.value) return undefined;
-  const v = getGkdAppInfo(snapshot.value).versionName;
-  return v ? `GKD@${v}` : undefined;
-});
-const appVersionCodeText = computed(() => {
-  if (!snapshot.value) return '';
-  const versionCode = getAppInfo(snapshot.value)?.versionCode;
-  return versionCode == null ? '' : String(versionCode);
-});
 </script>
 
 <template>
@@ -207,7 +118,7 @@ const appVersionCodeText = computed(() => {
         </NTooltip>
 
         <div flex items-center gap-2px max-w-120px>
-          <NTooltip v-if="isSystem && snapshot">
+          <NTooltip v-if="isSystem && app">
             <template #trigger>
               <SvgIcon
                 name="system"
@@ -215,14 +126,13 @@ const appVersionCodeText = computed(() => {
                 class="text-yellow-600"
               />
             </template>
-            {{ `${getAppInfo(snapshot).name} 是一个系统应用` }}
+            {{ `${app.name} 是一个系统应用` }}
           </NTooltip>
           <NTooltip>
             <template #trigger>
-              <div v-if="snapshot" @click="copy(getAppInfo(snapshot).name)">
-                {{ getAppInfo(snapshot).name }}
+              <div @click="copy(app?.name || '')">
+                {{ app?.name || '-' }}
               </div>
-              <div v-else>-</div>
             </template>
             应用名称
           </NTooltip>
@@ -230,13 +140,9 @@ const appVersionCodeText = computed(() => {
 
         <NTooltip>
           <template #trigger>
-            <div
-              v-if="snapshot"
-              @click="copy(getAppInfo(snapshot).versionName)"
-            >
-              {{ getAppInfo(snapshot).versionName }}
+            <div @click="copy(app?.versionName || '')">
+              {{ app?.versionName || '-' }}
             </div>
-            <div v-else>-</div>
           </template>
           版本名称
         </NTooltip>

--- a/src/views/snapshot/WindowCard.vue
+++ b/src/views/snapshot/WindowCard.vue
@@ -44,8 +44,8 @@ const {
   treeContainer,
 });
 
-const renderLabel = createRenderLabel(({ option, label }) =>
-  slots.renderLabel?.({ option, label }),
+const renderLabel = createRenderLabel(
+  ({ option, label }) => slots.renderLabel?.({ option, label }) ?? label,
 );
 
 const onDelete = async () => {

--- a/src/views/snapshot/WindowCard.vue
+++ b/src/views/snapshot/WindowCard.vue
@@ -2,17 +2,10 @@
 // ... 保持 import 不变 ...
 import ActionCard from '@/components/ActionCard.vue';
 import GapList from '@/components/GapList';
+import { useSnapshotWindowCard } from '@/composables/useSnapshotWindowCard';
 import { message } from '@/utils/discrete';
-import {
-  getAppInfo,
-  getDevice,
-  getGkdAppInfo,
-  getNodeLabel,
-  getNodeStyle,
-} from '@/utils/node';
 import { copy, delay } from '@/utils/others';
-import type { TreeInst, TreeOption, TreeProps } from 'naive-ui';
-import type { HTMLAttributes, ShallowRef, VNode } from 'vue';
+import type { ShallowRef, VNode } from 'vue';
 import { useSnapshotStore } from './snapshot';
 
 const slots = defineSlots<{
@@ -28,107 +21,32 @@ const { updateFocusNode, focusNode, focusTime } = snapshotStore;
 const snapshot = snapshotStore.snapshot as ShallowRef<Snapshot>;
 const rootNode = snapshotStore.rootNode as ShallowRef<RawNode>;
 
-let lastClickId = Number.NaN;
-const expandedKeys = shallowRef<number[]>([]);
-const selectedKeys = shallowRef<number[]>([]);
-const treeRef = shallowRef<TreeInst>();
 const treeContainer = useTemplateRef('treeContainerRef');
-const toRawNode = (option: TreeOption): RawNode => option as RawNode;
-const rootTreeData = computed<TreeOption[]>(() =>
-  rootNode.value ? [rootNode.value as TreeOption] : [],
+const {
+  expandedKeys,
+  selectedKeys,
+  treeRef,
+  rootTreeData,
+  treeFilter,
+  treeNodeProps,
+  createRenderLabel,
+  app,
+  deviceName,
+  activityId,
+  gkdVersionName,
+  appVersionCodeText,
+} = useSnapshotWindowCard({
+  snapshot,
+  rootNode,
+  focusNode,
+  focusTime,
+  updateFocusNode,
+  treeContainer,
+});
+
+const renderLabel = createRenderLabel(({ option, label }) =>
+  slots.renderLabel?.({ option, label }),
 );
-watch([() => focusNode.value, () => focusTime.value], async () => {
-  if (!focusNode.value) return;
-  const key = focusNode.value.id;
-  nextTick().then(async () => {
-    await delay(300);
-    if (key === focusNode.value?.id) {
-      if (lastClickId === key) {
-        lastClickId = Number.NaN;
-        return;
-      }
-      selectedKeys.value = [key];
-      if (!treeContainer.value) return;
-      const nodeRef = treeContainer.value.querySelector(
-        `[data-node-id="${key}"]`,
-      );
-      if (nodeRef) {
-        nodeRef.scrollIntoView({
-          behavior: 'smooth',
-          block: 'center',
-        });
-      } else {
-        await delay(300);
-        treeRef.value?.scrollTo({ key, behavior: 'smooth', debounce: true });
-      }
-    }
-  });
-  let parent = focusNode.value.parent;
-  if (!parent) return;
-  const s = new Set(expandedKeys.value);
-  while (parent) {
-    s.add(parent.id);
-    parent = parent.parent;
-  }
-  if (
-    s.size == expandedKeys.value.length &&
-    expandedKeys.value.every((v) => s.has(v))
-  )
-    return;
-  expandedKeys.value = [...s];
-});
-
-const treeFilter: NonNullable<TreeProps['filter']> = (_pattern, node) =>
-  toRawNode(node).id === focusNode.value?.id;
-
-const treeNodeProps: NonNullable<TreeProps['nodeProps']> = ({
-  option,
-}): HTMLAttributes & Record<string, unknown> => {
-  const rawNode = toRawNode(option);
-  const style = getNodeStyle(rawNode, focusNode.value);
-  return {
-    onClick: () => {
-      lastClickId = rawNode.id;
-      updateFocusNode(rawNode);
-    },
-    style: { '--n-node-text-color': style.color, ...style },
-    class: 'whitespace-nowrap',
-    'data-node-id': String(rawNode.id),
-  };
-};
-
-const renderLabel: NonNullable<TreeProps['renderLabel']> = ({ option }) => {
-  const rawNode = toRawNode(option);
-  const label = getNodeLabel(rawNode);
-  if (slots.renderLabel) return slots.renderLabel({ option: rawNode, label });
-  return label;
-};
-
-// --- 计算属性优化：提取 app 为内部变量，减少重复计算 ---
-const app = computed(() =>
-  snapshot.value ? getAppInfo(snapshot.value) : null,
-);
-
-const deviceName = computed(() => {
-  if (!snapshot.value) return '';
-  const device = getDevice(snapshot.value);
-  return `${device.manufacturer} Android ${device.release || ''}`;
-});
-
-const activityId = computed(() => {
-  if (!snapshot.value) return '';
-  const { activityId: v, appId } = snapshot.value;
-  if (!v || !appId) return '';
-  return v.startsWith(appId) && v[appId.length] === '.'
-    ? v.substring(appId.length)
-    : v;
-});
-
-const gkdVersionName = computed(() => {
-  if (!snapshot.value) return undefined;
-  const v = getGkdAppInfo(snapshot.value).versionName;
-  return v ? `GKD@${v}` : undefined;
-});
 
 const onDelete = async () => {
   message.success(`删除成功,即将回到首页`);
@@ -195,8 +113,8 @@ const onDelete = async () => {
 
         <NTooltip>
           <template #trigger>
-            <div @click="copy(app?.versionCode?.toString() || '')">
-              {{ app?.versionCode || '-' }}
+            <div @click="copy(appVersionCodeText)">
+              {{ appVersionCodeText || '-' }}
             </div>
           </template>
           版本代码


### PR DESCRIPTION
`WindowCard` 的公共逻辑抽成中性 seam

- 新增 [useSnapshotWindowCard.ts](C:\Users\cjy08\Documents\GitHub\inspect-plus\src\composables\useSnapshotWindowCard.ts)
- `src/views/snapshot/WindowCard.vue` 和 `src/views/plus/snapshot/WindowCard.vue` 复用它
- 公共内容包括：节点树状态、focus 滚动、节点点击 props、设备/应用信息计算
- Plus 独有的 quick-find 标记仍然留在 `views/plus/snapshot/WindowCard.vue`
- 更新了 `docs/TODO.md`

